### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,5 @@ import { data } from "../wasm/pkg/jazz_crypto_rs.wasm.js";
 let output: InitOutput | undefined = undefined;
 
 export async function initialize() {
-	return (output ??= await __wbg_init(data));
+  return (output ??= await __wbg_init({ module_or_path: data }));
 }


### PR DESCRIPTION
Fixes `using deprecated parameters for the initialization function; pass a single object` warning.

Closes https://github.com/garden-co/jazz/issues/1438.