### PR TITLE
fix(`wasm-opt`): add `--enable-bulk-memory` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,10 @@
 		"typescript": "^5.0.0",
 		"wasm-pack": "^0.13.1"
 	},
-	"packageManager": "pnpm@10.3.0"
+	"packageManager": "pnpm@10.3.0",
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"wasm-pack"
+		]
+	}
 }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -39,3 +39,9 @@ strip = true
 [profile.dev]
 opt-level = 0
 debug = true
+
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ['-O', '--enable-bulk-memory']
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '--enable-bulk-memory']


### PR DESCRIPTION
Rust 1.87 upgraded to LLVM 20, which broke builds of `jazz-crypto-rs` as it enabled bulk-memory by default (documented at https://doc.rust-lang.org/rustc/platform-support/wasm32-unknown-unknown.html#enabled-webassembly-features). Therefore, `wasm-opt` needs to be configured to expect it.

For more information, see the following GitHub issues:
- https://github.com/rust-lang/rust/issues/141080
- https://github.com/rust-lang/rust/issues/141048
- https://github.com/rust-lang/rust/issues/137315